### PR TITLE
Updated args for latest meeting minutes function

### DIFF
--- a/includes/meeting_functions.php
+++ b/includes/meeting_functions.php
@@ -353,6 +353,14 @@ function ucf_bot_get_latest_meeting_minutes( $committee='None', $args=array() ) 
 			array(
 				'key'     => 'ucf_meeting_minutes',
 				'compare' => 'EXISTS'
+			),
+			array(
+				'key'     => 'ucf_meeting_minutes',
+				'compare' => 'NOT IN',
+				'value'   => array(
+					'',
+					null
+				)
 			)
 		)
 	);


### PR DESCRIPTION
<!---
Thank you for contributing to BOT-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/BOT-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updated the query args for fetching the latest meeting minutes to make sure the meeting minutes postmeta is not null or an empty string.

**Motivation and Context**
If minutes are added to a meeting and then removed, it leaves the postmeta row in the db, but sets the value to an empty string. This causes the current arguments to pull that post, but then fail to display the minutes, because there's no file.

**How Has This Been Tested?**
Changes are available for review in DEV and QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
